### PR TITLE
Upgrade to Mule 3.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,8 +9,8 @@
     <name>Mule ZeroMQ Transport</name>
 
     <properties>
-        <mule.version>3.4.0</mule.version>
-        <mule.devkit.version>3.3-RC3</mule.devkit.version>
+        <mule.version>3.5.0</mule.version>
+        <mule.devkit.version>3.5.0</mule.devkit.version>
         <junit.version>4.10</junit.version>
     </properties>
 
@@ -76,10 +76,16 @@
             <artifactId>mule-module-spring-config</artifactId>
             <version>${mule.version}</version>
         </dependency>
+
         <dependency>
             <groupId>org.mule.tools.devkit</groupId>
             <artifactId>mule-devkit-annotations</artifactId>
             <version>${mule.devkit.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.mule.tools.devkit</groupId>
+            <artifactId>mule-devkit-dynamic-api</artifactId>
+            <version>3.5.0</version>
         </dependency>
         <dependency>
             <groupId>org.mule.modules</groupId>

--- a/src/main/java/org/mule/transport/zmq/adapters/ZMQTransportCapabilitiesAdapter.java
+++ b/src/main/java/org/mule/transport/zmq/adapters/ZMQTransportCapabilitiesAdapter.java
@@ -15,22 +15,25 @@
  */
 package org.mule.transport.zmq.adapters;
 
-import org.mule.api.Capabilities;
-import org.mule.api.Capability;
+
+import org.mule.api.devkit.capability.Capabilities;
+import org.mule.api.devkit.capability.ModuleCapability;
 import org.mule.transport.zmq.ZMQTransport;
 
 
 public class ZMQTransportCapabilitiesAdapter extends ZMQTransport implements Capabilities {
 
 
-    public boolean isCapableOf(Capability capability) {
-        if (capability == Capability.LIFECYCLE_CAPABLE) {
+    @Override
+    public boolean isCapableOf(ModuleCapability capability) {
+        if (capability == ModuleCapability.LIFECYCLE_CAPABLE) {
             return true;
         }
-        if (capability == Capability.CONNECTION_MANAGEMENT_CAPABLE) {
+        if (capability == ModuleCapability.CONNECTION_MANAGEMENT_CAPABLE) {
             return true;
         }
         return false;
     }
+
 
 }

--- a/src/main/java/org/mule/transport/zmq/adapters/ZMQTransportLifecycleAdapter.java
+++ b/src/main/java/org/mule/transport/zmq/adapters/ZMQTransportLifecycleAdapter.java
@@ -18,13 +18,14 @@ package org.mule.transport.zmq.adapters;
 import org.mule.api.MuleException;
 import org.mule.api.lifecycle.*;
 import org.mule.config.MuleManifest;
+import org.mule.devkit.dynamic.api.helper.Connection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 
 public class ZMQTransportLifecycleAdapter
         extends ZMQTransportCapabilitiesAdapter
-        implements Disposable, Initialisable, Startable, Stoppable {
+        implements Disposable, Initialisable, Startable, Stoppable, Connection {
 
 
     public void start() throws MuleException {
@@ -33,6 +34,12 @@ public class ZMQTransportLifecycleAdapter
 
     public void stop()
             throws MuleException {
+    }
+
+    @Override
+    public String getConnectionIdentifier() {
+        // ToDo JD implement
+        return null;  //To change body of implemented methods use File | Settings | File Templates.
     }
 
     public void initialise() {

--- a/src/main/java/org/mule/transport/zmq/adapters/ZMQTransportLifecycleAdapter.java
+++ b/src/main/java/org/mule/transport/zmq/adapters/ZMQTransportLifecycleAdapter.java
@@ -38,8 +38,7 @@ public class ZMQTransportLifecycleAdapter
 
     @Override
     public String getConnectionIdentifier() {
-        // ToDo JD implement
-        return null;  //To change body of implemented methods use File | Settings | File Templates.
+        return super.connectionId();
     }
 
     public void initialise() {

--- a/src/main/java/org/mule/transport/zmq/sources/InboundEndpointMessageSource.java
+++ b/src/main/java/org/mule/transport/zmq/sources/InboundEndpointMessageSource.java
@@ -64,6 +64,11 @@ public class InboundEndpointMessageSource implements Runnable, SourceCallback, F
 
     private Thread thread;
 
+    @Override
+    public MuleEvent processEvent(MuleEvent muleEvent) throws MuleException {
+        return muleEvent;
+    }
+
     public void initialise()
             throws InitialisationException {
         if (moduleObject == null) {


### PR DESCRIPTION
Hey Claude,

I took a stab at upgrading this for Mule 3.5.0.  Please review the getDefaultConnectionKey() method in ZeroMQTransportConnectionManager.java.  I wasn't sure if there's a better way to determine inbound vs. outbound other then if the receiverThreadingProfile is null or not.
